### PR TITLE
Fix "Unexepcted token import" bug for ES6 projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   ],
   "main": "src/index.js",
   "scripts": {
-    "build": "webpack"
+    "build": "webpack",
+    "install": "webpack"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Build dist on npm install to avoid "Unexpected token import" with ES6 projects that don't have babel looking at node_modules